### PR TITLE
Updated package.json template to bump up lodash.template to 3.5.1

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -9,7 +9,7 @@
     "babelify": "5.0.3",
     "gulp": "^3.8.6",
     "gulp-minify-css": "^0.3.6",
-    "lodash.template" : "3.0.0",
+    "lodash.template" : "3.5.1",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^0.7.2",
     "vinyl-source-stream": "^1.0.0",


### PR DESCRIPTION
This fixes issue https://github.com/clappr/generator-clappr-plugin/issues/17 where I couldn't build on windows.
